### PR TITLE
docs: Add link to PM_model$fit in internal function fit

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -50,6 +50,8 @@ dummy_compile <- function(template_path) .Call(wrap__dummy_compile, template_pat
 is_cargo_installed <- function() .Call(wrap__is_cargo_installed)
 
 #' Fits the model at the given path to the data at the given path using the provided parameters.
+#' NOTE: This is an internal function and should not be called directly.
+#' See [PM_model] `$fit()` method for arguments.
 #' @param model_path Path to the compiled model file.
 #' @param data Path to the data file.
 #' @param params List of fitting parameters.

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -51,7 +51,7 @@ is_cargo_installed <- function() .Call(wrap__is_cargo_installed)
 
 #' Fits the model at the given path to the data at the given path using the provided parameters.
 #' NOTE: This is an internal function and should not be called directly.
-#' See [PM_model] `$fit()` method for arguments.
+#' See [PM_model()] `$fit()` method for arguments.
 #' @param model_path Path to the compiled model file.
 #' @param data Path to the data file.
 #' @param params List of fitting parameters.

--- a/man/fit.Rd
+++ b/man/fit.Rd
@@ -2,7 +2,9 @@
 % Please edit documentation in R/extendr-wrappers.R
 \name{fit}
 \alias{fit}
-\title{Fits the model at the given path to the data at the given path using the provided parameters.}
+\title{Fits the model at the given path to the data at the given path using the provided parameters.
+NOTE: This is an internal function and should not be called directly.
+See \link{PM_model} \verb{$fit()} method for arguments.}
 \usage{
 fit(model_path, data, params, output_path, kind)
 }
@@ -22,4 +24,6 @@ Result of the fitting process.
 }
 \description{
 Fits the model at the given path to the data at the given path using the provided parameters.
+NOTE: This is an internal function and should not be called directly.
+See \link{PM_model} \verb{$fit()} method for arguments.
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -119,7 +119,7 @@ fn simulate_all(
 
 /// Fits the model at the given path to the data at the given path using the provided parameters.
 /// #' NOTE: This is an internal function and should not be called directly.
-/// #' See [PM_model] `$fit()` method for arguments.
+/// #' See [PM_model()] `$fit()` method for arguments.
 /// @param model_path Path to the compiled model file.
 /// @param data Path to the data file.
 /// @param params List of fitting parameters.

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -117,8 +117,9 @@ fn simulate_all(
     rows.into_dataframe().unwrap()
 }
 
-
 /// Fits the model at the given path to the data at the given path using the provided parameters.
+/// #' NOTE: This is an internal function and should not be called directly.
+/// #' See [PM_model] `$fit()` method for arguments.
 /// @param model_path Path to the compiled model file.
 /// @param data Path to the data file.
 /// @param params List of fitting parameters.


### PR DESCRIPTION
If the user simply uses `?fit`, they are redirected to the Rust function.

I wonder if this function should not be made public, as it is not meant for users to call directly.